### PR TITLE
Fix topbar actions break after successful on profile operation

### DIFF
--- a/public/utils/reuseableEventListeners.js
+++ b/public/utils/reuseableEventListeners.js
@@ -2,19 +2,20 @@ import { apiRequest as api } from './api-utils.js';
 
 // Reuseable event listener for logout button - by default looks for element with id 'logout-btn'
 function logoutEventListener(btnId = 'logout-btn') {
-    const logout = document.getElementById(btnId);
-    if (logout) {
-        logout.addEventListener('click', async () => {
-            try {
-                const response = await api('/api/auth/logout', 'POST');
-                // Redirect to login after logout
-                window.location.href = '/login';
-            } catch (err) {
-                console.error('Logout failed:', err);
-                window.location.href = '/login';
-            }
-        });
+  document.body.addEventListener('click', async (e) => {
+    const logoutButton = e.target.closest(`#${btnId}`);
+    if (logoutButton) {
+        e.preventDefault();
+        try {
+            const response = await api('/api/auth/logout', 'POST');
+            window.location.href = '/login';
+        } catch (err) {
+            console.error('Logout failed:', err);
+            window.location.href = '/login';
+        }
+        return;
     }
+    });
 }
 
 // Export functions for use in other files


### PR DESCRIPTION
This PR fixes #55 .
It does so by creating a click listener on the body element of the page, which always exist. Allowing click listening on reloaded objects (objects which get destroyed and recreated in order to perform an update).